### PR TITLE
[es]: Improved translations

### DIFF
--- a/locales/es/json.json
+++ b/locales/es/json.json
@@ -19,7 +19,7 @@
     "Gone": "Recurso no disponible",
     "HTTP Version Not Supported": "Versión HTTP no compatible",
     "I'm a teapot": "Soy una tetera",
-    "IM Used": "Estoy usado",
+    "IM Used": "IM usado",
     "Insufficient Storage": "Espacio insuficiente",
     "Internal Server Error": "Error interno del servidor",
     "Invalid SSL Certificate": "Certificado SSL no válido",

--- a/locales/es/php.json
+++ b/locales/es/php.json
@@ -12,7 +12,7 @@
     "206": "Contenido parcial",
     "207": "Multiestado",
     "208": "Ya Reportado",
-    "226": "Estoy usado",
+    "226": "IM usado",
     "300": "Múltiples opciones",
     "301": "Movido permanentemente",
     "302": "Encontrado",


### PR DESCRIPTION
HTTP Status: **226** : IM Used

Translator *mistakenly* translates "**IM**" in Spanish as "**I'm**" or "**I am**", which does not make sense.

According to the [documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/226) **IM** stands for *instance manipulations* the term used to describe an algorithm generating a *delta*.
