### PR TITLE
[fr]: Fix translations for HTTP statuses

### DIFF
--- a/locales/fr/php.json
+++ b/locales/fr/php.json
@@ -54,7 +54,7 @@
     "449": "Réessayer avec",
     "451": "Indisponible pour des raisons légales",
     "499": "Demande fermée par le client",
-    "500": "Erreur interne dus erveur",
+    "500": "Erreur interne du serveur",
     "501": "Non implémenté",
     "502": "Mauvaise passerelle",
     "503": "Service non disponible",


### PR DESCRIPTION
This PR fixes a typo in the `locales/fr/php.json` file for the HTTP status 500 translation.

Before:
"500": "Erreur interne dus erveur"

After:
"500": "Erreur interne du serveur"

This change improves the accuracy and consistency of the French translations for HTTP statuses.
