### PR TITLE
[pt_BR]: Spelling correction

### DIFF
--- a/locales/pt_BR/json.json
+++ b/locales/pt_BR/json.json
@@ -44,7 +44,7 @@
     "Not Modified": "Não Modificado",
     "OK": "OK",
     "Origin Is Unreachable": "Origem É Inacessível",
-    "Partial Content": "Contéudo Parcial",
+    "Partial Content": "Conteúdo Parcial",
     "Payload Too Large": "Carga Muito Grande",
     "Payment Required": "Pagamento Requerido",
     "Permanent Redirect": "Redirecionamento Permanente",

--- a/locales/pt_BR/php.json
+++ b/locales/pt_BR/php.json
@@ -9,7 +9,7 @@
     "203": "Informações Não Autorizadas",
     "204": "Nenhum Conteúdo",
     "205": "Redefinir Conteúdo",
-    "206": "Contéudo Parcial",
+    "206": "Conteúdo Parcial",
     "207": "Vários status",
     "208": "Já Reportado",
     "226": "Estou Usando",


### PR DESCRIPTION
"Conteúdo" was written as "Contéudo"